### PR TITLE
feat: add support for ReuseAddr

### DIFF
--- a/listen_reuseport.go
+++ b/listen_reuseport.go
@@ -25,19 +25,39 @@ func reuseportControl(network, address string, c syscall.RawConn) error {
 	return opErr
 }
 
-func listenTCP(network, addr string, reuseport bool) (net.Listener, error) {
+func reuseaddrControl(network, address string, c syscall.RawConn) error {
+	var opErr error
+	err := c.Control(func(fd uintptr) {
+		opErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+	})
+	if err != nil {
+		return err
+	}
+
+	return opErr
+}
+
+func listenTCP(network, addr string, reuseport bool, reuseaddr bool) (net.Listener, error) {
 	var lc net.ListenConfig
-	if reuseport {
+	switch {
+	case reuseaddr && reuseport:
+	case reuseport:
 		lc.Control = reuseportControl
+	case reuseaddr:
+		lc.Control = reuseaddrControl
 	}
 
 	return lc.Listen(context.Background(), network, addr)
 }
 
-func listenUDP(network, addr string, reuseport bool) (net.PacketConn, error) {
+func listenUDP(network, addr string, reuseport bool, reuseaddr bool) (net.PacketConn, error) {
 	var lc net.ListenConfig
-	if reuseport {
+	switch {
+	case reuseaddr && reuseport:
+	case reuseport:
 		lc.Control = reuseportControl
+	case reuseaddr:
+		lc.Control = reuseaddrControl
 	}
 
 	return lc.ListenPacket(context.Background(), network, addr)

--- a/server.go
+++ b/server.go
@@ -240,6 +240,7 @@ type Server struct {
 	// It is only supported on certain GOOSes and when using ListenAndServe.
 	ReusePort bool
 	// Whether to set the SO_REUSEADDR socket option, allowing multiple listeners to be bound to a single address.
+	// Crucially this allows binding when an existing server is listening on `0.0.0.0` or `::`.
 	// It is only supported on certain GOOSes and when using ListenAndServe.
 	ReuseAddr bool
 	// AcceptMsgFunc will check the incoming message and will reject it early in the process.

--- a/server.go
+++ b/server.go
@@ -239,6 +239,9 @@ type Server struct {
 	// Whether to set the SO_REUSEPORT socket option, allowing multiple listeners to be bound to a single address.
 	// It is only supported on certain GOOSes and when using ListenAndServe.
 	ReusePort bool
+	// Whether to set the SO_REUSEADDR socket option, allowing multiple listeners to be bound to a single address.
+	// It is only supported on certain GOOSes and when using ListenAndServe.
+	ReuseAddr bool
 	// AcceptMsgFunc will check the incoming message and will reject it early in the process.
 	// By default DefaultMsgAcceptFunc will be used.
 	MsgAcceptFunc MsgAcceptFunc
@@ -317,7 +320,7 @@ func (srv *Server) ListenAndServe() error {
 
 	switch srv.Net {
 	case "tcp", "tcp4", "tcp6":
-		l, err := listenTCP(srv.Net, addr, srv.ReusePort)
+		l, err := listenTCP(srv.Net, addr, srv.ReusePort, srv.ReuseAddr)
 		if err != nil {
 			return err
 		}
@@ -330,7 +333,7 @@ func (srv *Server) ListenAndServe() error {
 			return errors.New("dns: neither Certificates nor GetCertificate set in Config")
 		}
 		network := strings.TrimSuffix(srv.Net, "-tls")
-		l, err := listenTCP(network, addr, srv.ReusePort)
+		l, err := listenTCP(network, addr, srv.ReusePort, srv.ReuseAddr)
 		if err != nil {
 			return err
 		}
@@ -340,7 +343,7 @@ func (srv *Server) ListenAndServe() error {
 		unlock()
 		return srv.serveTCP(l)
 	case "udp", "udp4", "udp6":
-		l, err := listenUDP(srv.Net, addr, srv.ReusePort)
+		l, err := listenUDP(srv.Net, addr, srv.ReusePort, srv.ReusePort)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Thanks for you pull request, do note the following:

* If your PR introduces backward incompatible changes it will very likely not be merged.

* We support the last two major Go versions, if your PR uses features from a too new Go version, it
    will not be merged.
